### PR TITLE
fix config context overrides for secrets

### DIFF
--- a/changes/155.fixed
+++ b/changes/155.fixed
@@ -1,0 +1,1 @@
+Fixed secrets group access type overrides not working.

--- a/changes/155.fixed
+++ b/changes/155.fixed
@@ -1,1 +1,0 @@
-Fixed secrets group access type overrides not working.

--- a/docs/admin/release_notes/version_1.0.md
+++ b/docs/admin/release_notes/version_1.0.md
@@ -5,6 +5,11 @@
 
 - Add provider class for Nautobot Secrets Functionality
 
+## [v1.0.5] - 2024-04
+
+### Fixed
+
+- [#155](https://github.com/nautobot/nautobot-plugin-nornir/issues/155) - Fixed secrets group access type overrides not working.
 
 ## [v1.0.4] - 2024-04
 

--- a/nautobot_plugin_nornir/plugins/credentials/nautobot_secrets.py
+++ b/nautobot_plugin_nornir/plugins/credentials/nautobot_secrets.py
@@ -24,7 +24,7 @@ creds_cache = {
 import json
 
 from nautobot.extras.choices import SecretsGroupAccessTypeChoices, SecretsGroupSecretTypeChoices
-from nautobot_plugin_nornir.constants import PLUGIN_CFG
+from nautobot_plugin_nornir.constants import NORNIR_SETTINGS
 
 from .nautobot_orm import MixinNautobotORMCredentials
 
@@ -38,7 +38,7 @@ def _get_access_type_value(device_obj):
     Returns:
         SecretsGroupAccessTypeChoices: Choice
     """
-    if PLUGIN_CFG.get("use_config_context", {}).get("secrets"):
+    if NORNIR_SETTINGS.get("use_config_context", {}).get("secrets"):
         access_type_str = device_obj.get_config_context()["nautobot_plugin_nornir"]["secret_access_type"].upper()
         access_type = getattr(SecretsGroupAccessTypeChoices, f"TYPE_{access_type_str}")
     else:

--- a/nautobot_plugin_nornir/plugins/credentials/nautobot_secrets.py
+++ b/nautobot_plugin_nornir/plugins/credentials/nautobot_secrets.py
@@ -40,6 +40,8 @@ def _get_access_type_value(device_obj):
     """
     if NORNIR_SETTINGS.get("use_config_context", {}).get("secrets"):
         access_type_str = device_obj.get_config_context()["nautobot_plugin_nornir"]["secret_access_type"].upper()
+        if access_type_str == "HTTP(S)":
+            access_type_str = "HTTP"
         access_type = getattr(SecretsGroupAccessTypeChoices, f"TYPE_{access_type_str}")
     else:
         access_type = SecretsGroupAccessTypeChoices.TYPE_GENERIC
@@ -128,12 +130,13 @@ class CredentialsNautobotSecrets(MixinNautobotORMCredentials):
             self.secret = None
             for sec in device.secrets_group.secrets.all():
                 secret_value = self.creds_cache.get(self._get_or_cache_secret_key(device, sec))
+                sec_access_type = f"TYPE_{sec.secretsgroupassociation_set.first().access_type.upper()}"
+                if sec_access_type == "TYPE_HTTP(S)":
+                    sec_access_type = "TYPE_HTTP"
                 current_secret_type = getattr(
                     SecretsGroupSecretTypeChoices, f"TYPE_{sec.secretsgroupassociation_set.first().secret_type.upper()}"
                 )
-                current_access_type = getattr(
-                    SecretsGroupAccessTypeChoices, f"TYPE_{sec.secretsgroupassociation_set.first().access_type.upper()}"
-                )
+                current_access_type = getattr(SecretsGroupAccessTypeChoices, sec_access_type)
                 configured_access_type = _get_access_type_value(device)
                 if (
                     current_secret_type == SecretsGroupSecretTypeChoices.TYPE_USERNAME

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-plugin-nornir"
-version = "1.0.4"
+version = "1.0.5"
 description = "Nautobot Nornir plugin."
 authors = ["Network to Code, LLC <info@networktocode.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
The wrong constant was being used in the the overrides code, which leaded to `use_config_context` for secrets to never actually be overloaded.